### PR TITLE
[DEVOPS-18799] - Emit events for sleeps

### DIFF
--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -439,6 +439,8 @@ func (r *VaultDynamicSecretReconciler) syncSecret(ctx context.Context, c vault.C
 	}
 
 	if ad := os.Getenv("ARTIFICIAL_DELAY"); ad != "" {
+		r.Recorder.Eventf(o, corev1.EventTypeNormal, "SyncSecretArtificialDelay",
+			"Introducing ARTIFICIAL_DELAY during syncSecret for %s", ad)
 		d, err := time.ParseDuration(ad)
 		if err != nil {
 			logger.Error(err, "Invalid ARTIFICIAL_DELAY value, sleeping for 60 seconds")

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -853,7 +854,8 @@ func Test_artificialDelay(t *testing.T) {
 				require.NoError(t, os.Setenv(env, val))
 			}
 			r := &VaultDynamicSecretReconciler{
-				Client: tt.fields.Client,
+				Client:   tt.fields.Client,
+				Recorder: &record.FakeRecorder{},
 			}
 			start := time.Now()
 			_, _, err := r.syncSecret(tt.args.ctx, tt.args.vClient, tt.args.o, nil)


### PR DESCRIPTION
While debugging an issue with VSO, it would have been handy to have events

https://salesloft.atlassian.net/browse/DEVOPS-18799